### PR TITLE
Extract footer comment into a config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It is possible to override default configuration by adding a `.github/test-case-
 - `tests_repo` - Repository with test suites and `mapping.json`
 - `tests_dir` - Path to test-suites directory
 - `mapping_file` - Path to `mapping.json` file
+- `comment_footer` - Markdown-formatted text that will be added _after_ list of test cases. Useful for suggestions on how to improve/extend existing test cases
 
 Example config:
 
@@ -20,7 +21,8 @@ Example config:
 {
   "tests_repo": "brbrr/jetpack",
   "tests_dir": "docs/regression-checklist/test-suites/",
-  "mapping_file": "docs/regression-checklist/mapping.json"
+  "mapping_file": "docs/regression-checklist/mapping.json",
+  "comment_footer": "Text explaining how to extend and improve existing test suites"
 }
 ```
 

--- a/application_helper.rb
+++ b/application_helper.rb
@@ -9,11 +9,6 @@ module ApplicationHelper
   # The GitHub App's identifier (type integer) set when registering an app.
   APP_IDENTIFIER = ENV['GITHUB_APP_IDENTIFIER']
 
-  # Default configuration
-  TESTS_DIR = 'test-suites/'
-  TESTS_MAPPING_FILE = 'config/mapping.json' 
-  TESTS_REPO = 'wordpress-mobile/test-cases'
-  
   def handle_pullrequest_opened_event(payload)
     repo = payload['repository']['full_name']
     pr_number = payload['pull_request']['number']
@@ -41,7 +36,8 @@ module ApplicationHelper
     {
       tests_dir: 'test-suites/',
       mapping_file: 'config/mapping.json',
-      tests_repo: 'wordpress-mobile/test-cases'
+      tests_repo: 'wordpress-mobile/test-cases',
+      comment_footer: "\n\nIf you think that suggestions should be improved please edit the configuration file [here](https://github.com/wordpress-mobile/test-cases/blob/master/config/mapping.json). You can also modify/add [test-suites](https://github.com/wordpress-mobile/test-cases/tree/master/test-suites) to be used in the [configuration](https://github.com/wordpress-mobile/test-cases/blob/master/config/mapping.json).\n\n If you are a beginner in mobile platforms follow [build instructions](https://github.com/wordpress-mobile/test-cases/blob/master/README.md#build-instructions).",
     }
   end
 
@@ -103,7 +99,7 @@ module ApplicationHelper
           testFile = Octokit.contents(config[:tests_repo], :path => config[:tests_dir] + file)
           testContent = testContent + Base64.decode64(testFile['content'])
     }
-    testContent = testContent + "\n\n" + " If you think that suggestions should be improved please edit the configuration file [here](https://github.com/wordpress-mobile/test-cases/blob/master/config/mapping.json). You can also modify/add [test-suites](https://github.com/wordpress-mobile/test-cases/tree/master/test-suites) to be used in the [configuration](https://github.com/wordpress-mobile/test-cases/blob/master/config/mapping.json).\n\n If you are a beginner in mobile platforms follow [build instructions](https://github.com/wordpress-mobile/test-cases/blob/master/README.md#build-instructions)."
+    testContent = testContent + config[:comment_footer]
   end
 
   # Saves the raw payload and converts the payload to JSON format

--- a/unittests.rb
+++ b/unittests.rb
@@ -63,7 +63,8 @@ class TestAdd < Test::Unit::TestCase
         expected_config = {
             tests_dir: 'test-suites/',
             mapping_file: 'config/mapping.json',
-            tests_repo: 'wordpress-mobile/test-cases'
+            tests_repo: 'wordpress-mobile/test-cases',
+            comment_footer: "\n\nIf you think that suggestions should be improved please edit the configuration file [here](https://github.com/wordpress-mobile/test-cases/blob/master/config/mapping.json). You can also modify/add [test-suites](https://github.com/wordpress-mobile/test-cases/tree/master/test-suites) to be used in the [configuration](https://github.com/wordpress-mobile/test-cases/blob/master/config/mapping.json).\n\n If you are a beginner in mobile platforms follow [build instructions](https://github.com/wordpress-mobile/test-cases/blob/master/README.md#build-instructions).",
           }
         assert_equal(expected_config, default_config)
     end
@@ -72,7 +73,12 @@ class TestAdd < Test::Unit::TestCase
         ghApp = DummyClass.new()
       	logger = Logger.new(STDOUT)
 
-        expected_config = {tests_dir: 'tests_dir', mapping_file: 'mapping_file', tests_repo: 'tests_repo'}
+        expected_config = {
+            tests_dir: 'tests_dir',
+            mapping_file: 'mapping_file',
+            tests_repo: 'tests_repo',
+            comment_footer: 'comment_footer'
+        }
         content = Base64.encode64(expected_config.to_json)
 
         any_instance_of(Octokit::Client) do |klass|


### PR DESCRIPTION
This allows other repos to re-define hardcoded footer comment, to use correct test-case links and context. 